### PR TITLE
Scale tasgroup fix, Restart any feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Libra
-Libra autoscales [Nomad](nomadproject.io) task groups so you don't have to. View the API documentation [here](https://underarmour.github.io/libra).
+Libra autoscales [Nomad](https://nomadproject.io) task groups so you don't have to. View the API documentation [here](https://underarmour.github.io/libra).
 
 ## Design
 Libra takes heavy inspiration from the design of Nomad itself and uses a client/server model. Much like Nomad, the Libra CLI makes HTTP API calls to the Libra server.
@@ -19,7 +19,7 @@ The skeleton of this project is from [jippi/nomad-auto-scale](https://github.com
 * Handle Nomad errors more robustly
 
 ## Configuration
-You can (and probably should) configure five environment variables as well, `LIBRA_ADDR`, `LIBRA_CONFIG`, `GRAPHITE_PASSWORD`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
+You can (and probably should) configure five environment variables as well, `LIBRA_ADDR`, `LIBRA_CONFIG_DIR`, `GRAPHITE_PASSWORD`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
 
 Libra gets most of its configuration from HCL config files located in a config directory (default `/etc/libra`). Here's an example `config.hcl` file:
 

--- a/command/server.go
+++ b/command/server.go
@@ -44,7 +44,9 @@ func (c *ServerCommand) Run(args []string) int {
 		return 1
 	}
 
-	os.Setenv("LIBRA_CONFIG_DIR", c.ConfDir)
+	if os.Getenv("LIBRA_CONFIG_DIR") == "" || c.ConfDir != "/etc/libra"{
+		os.Setenv("LIBRA_CONFIG_DIR", c.ConfDir)
+	}
 	s := rest.NewApi()
 	logger := logrus.New()
 	w := logger.Writer()

--- a/nomad/nomad.go
+++ b/nomad/nomad.go
@@ -28,42 +28,57 @@ func NewClient(c Config) (*api.Client, error) {
 }
 
 // Scale increases or decreases the count of a task group
-func Scale(client *api.Client, jobID, groupID string, scale, min, max int) (string, int, error) {
+func Scale(client *api.Client, jobID, group string, scale, min, max int) (string, int, error) {
 	job, _, err := client.Jobs().Info(jobID, &api.QueryOptions{})
+	newCount := -1
 	if err != nil {
 		return "", 0, err
 	}
-	oldCount := *job.TaskGroups[0].Count
-	newCount := oldCount + scale
-	if newCount < min || newCount > max {
-		return "", oldCount, errors.New("the new group count (" + strconv.Itoa(newCount) + ") is outside of the configured range (" + strconv.Itoa(min) + "-" + strconv.Itoa(max) + ")")
+	for _, tg := range job.TaskGroups {
+		if *tg.Name == group {
+			oldCount := *tg.Count
+			newCount = oldCount + scale
+			if newCount < min || newCount > max {
+				return "", oldCount, errors.New("the new group count (" + strconv.Itoa(newCount) + ") is outside of the configured range (" + strconv.Itoa(min) + "-" + strconv.Itoa(max) + ")")
+			}
+			tg.Count = &newCount
+		}
 	}
-	job.TaskGroups[0].Count = &newCount
-	resp, _, _ := client.Jobs().Register(job, &api.WriteOptions{})
-	return resp.EvalID, newCount, nil
+	if newCount > -1 {
+		resp, _, _ := client.Jobs().Register(job, &api.WriteOptions{})
+		return resp.EvalID, newCount, nil
+	} else {
+		return "", -1, errors.New("could not find task group " + group + " in job " + jobID)
+	}
 }
 
 // Restart restarts a job to get the latest docker image
 func Restart(client *api.Client, jobID, group, task, image string) (string, error) {
+	found := false
 	job, _, err := client.Jobs().Info(jobID, &api.QueryOptions{})
 	if err != nil {
 		return "", err
 	}
 	for _, tg := range job.TaskGroups {
-		if *tg.Name == group {
+		if *tg.Name == group || group == "any" {
 			for _, t := range tg.Tasks {
-				if t.Name == task {
+				if t.Name == task || task == "any" {
 					t.Config["image"] = image
+					found = true
 				}
 			}
-			resp, _, err := client.Jobs().Register(job, &api.WriteOptions{})
-			if err != nil {
-				return "", err
-			}
-			return resp.EvalID, nil
 		}
 	}
-	return "", errors.New("could not find task group " + group + " in job " + jobID)
+	if found {
+		resp, _, err := client.Jobs().Register(job, &api.WriteOptions{})
+		if err != nil {
+			return "", err
+		}
+		return resp.EvalID, nil
+	} else {
+		return "", errors.New("could not find task group " + group + " in job " + jobID)
+	}
+
 }
 
 // SetCapacity sets the count of a task group


### PR DESCRIPTION
- Scale Function was increasing only the count of first group in job - now it's checking the name of group.
- Restart function (Deploy) - now has an ability to update the images of all tasks or groups.
In our use case we got a resque workers running in multiple groups, listening to different queues, so we're running the same docker image with different environment variables.